### PR TITLE
Add new backup files to be pushed into repo

### DIFF
--- a/.github/workflows/generate_readme.yml
+++ b/.github/workflows/generate_readme.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           git config --local user.email "${{ env.GITHUB_EMAIL }}"
           git config --local user.name "${{ env.GITHUB_EMAIL }}"
+          git add BACKUP/*.md
           git commit -a -m 'update new blog' || echo "nothing to commit"
           git push || echo "nothing to push"
 


### PR DESCRIPTION
Hi，yihong老师。

Fork您的Repo来做自己的gitblog一段时间，首先表示感谢。
我发现到在修改了`generate_readme.yml`使用git来push之后，因为新增BACKUP里的md文件并没有在其考虑范围，所以不会push到Repo里面。的确，我也看到您的`BACKUP`路径下，除现有文件因为Issue新增comment而获得更新外，新Issue并没有生成backup文件了。(以issue 237为例）

我简单的增加一个git add来进行修复，在我自己的repo已经完成测试可正确更新，请参考。