### PR TITLE
Sort lables by description info if it exists, otherwise sort by name

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,6 +188,11 @@ def add_md_header(md, repo_name):
 
 def add_md_label(repo, md, me):
     labels = get_repo_labels(repo)
+
+    # sort lables by description info if it exists, otherwise sort by name, 
+    # for example, we can let the description start with a number (1#Java, 2#Docker, 3#K8s, etc.)
+    labels = sorted(labels, key=lambda x: (x.description is None, x.description == "", x.description, x.name))
+
     with open(md, "a+", encoding="utf-8") as md:
         for label in labels:
 


### PR DESCRIPTION
For example, we can let the description start with a number (1#Java, 2#Docker, 3#K8s, etc.)