### PR TITLE
Fix the bug caused by the '/' in issue title.

### DIFF
--- a/main.py
+++ b/main.py
@@ -280,7 +280,7 @@ def main(token, repo_name, issue_number=None, dir_name=BACKUP_DIR):
 
 def save_issue(issue, me, dir_name=BACKUP_DIR):
     md_name = os.path.join(
-        dir_name, f"{issue.number}_{issue.title.replace(' ', '.')}.md"
+        dir_name, f"{issue.number}_{issue.title.replace('/', '-').replace(' ', '.')}.md"
     )
     with open(md_name, "w") as f:
         f.write(f"# [{issue.title}]({issue.html_url})\n\n")


### PR DESCRIPTION
yihong 你好：

  Fix the bug caused by the '/' in issue title.
  
  If the issue titile contains '/' like 'xxxx in 10/27', the save_issue function will fail.