### PR TITLE
将友情链接生成的markdown表格处理成html

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import argparse
 import os
 import re
 
+import markdown
 from marko.ext.gfm import gfm as marko
 from github import Github
 from feedgen.feed import FeedGenerator
@@ -160,9 +161,11 @@ def add_md_firends(repo, md, me):
                 except Exception as e:
                     print(str(e))
                     pass
+    s = markdown.markdown(s,output_format='html', extensions=['extra']) 
     with open(md, "a+", encoding="utf-8") as md:
         md.write("## 友情链接\n")
         md.write(s)
+        md.write("\n\n")
 
 
 def add_md_recent(repo, md, me, limit=5):
@@ -184,6 +187,7 @@ def add_md_recent(repo, md, me, limit=5):
 def add_md_header(md, repo_name):
     with open(md, "w", encoding="utf-8") as md:
         md.write(MD_HEAD.format(repo_name=repo_name))
+        md.write("\n")
 
 
 def add_md_label(repo, md, me):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyGithub
 feedgen
 marko
+markdown


### PR DESCRIPTION
GitHub pages默认仓库根目录下index.html为入口，因该仓库没有index文件，默认解析readme.md。
但是Jekyll不能很好的渲染markdown表格，导致通过{user}.github.io访问主页时友情链接部分会打乱排版。

通过引入markdown库，提前把mardown表格渲染后成html后再写入readme.md，保证了主页排版的展示效果。