### PR TITLE
Add conditions to control job execution in generate_readme.yml

### DIFF
--- a/.github/workflows/generate_readme.yml
+++ b/.github/workflows/generate_readme.yml
@@ -16,6 +16,7 @@ jobs:
   sync:
     name: Generate README
     runs-on: ubuntu-latest
+    if: github.repository_owner_id == github.envent.issue.user.id || github.envent_name == "push"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Make sure only issues created by the repo owner will trigger the workflows. 

Less action runs to save mother earth:)