### PR TITLE
fix: highlight code, bump isite version

### DIFF
--- a/.github/workflows/generate_site.yml
+++ b/.github/workflows/generate_site.yml
@@ -32,7 +32,7 @@ jobs:
       pages: write
     env:
       GH_TOKEN: ${{ github.token }}
-      ISITE_VERSION: v0.2.2
+      ISITE_VERSION: v0.2.4
       ZOLA_VERSION: v0.20.0
       USER: ${{ github.repository_owner }}
       REPO: ${{ github.event.repository.name }}
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Generate markdown
         run: |
-          gh release download $ISITE_VERSION --repo kemingy/isite -p '*Linux_x86_64*' --output isite.tar.gz
+          gh release download $ISITE_VERSION --repo kemingy/isite -p '*linux_amd64*' --output isite.tar.gz
           tar zxf isite.tar.gz && mv isite /usr/local/bin
           isite generate --user $USER --repo $REPO
           gh release download $ZOLA_VERSION --repo getzola/zola -p '*x86_64-unknown-linux*' --output zola.tar.gz

--- a/config.toml
+++ b/config.toml
@@ -14,3 +14,6 @@ even_menu = [
     {url = "$BASE_URL/issue-282/", name = "About"},
     {url = "$BASE_URL/issue-311/", name = "Things I like"},
 ]
+[markdown]
+highlight_code = true
+render_emoji = true


### PR DESCRIPTION
You are the 1st one to try the v0.2.4, the main change is that you can filter by tags (I fixed a query escape bug).

:tada: 